### PR TITLE
fix issue 61

### DIFF
--- a/src/pages/Game/FingerGuessing/index.tsx
+++ b/src/pages/Game/FingerGuessing/index.tsx
@@ -38,6 +38,7 @@ import {getEventsByTxnHash, getTxnData} from "../../../utils/sdk";
 import {sleep} from "../../../utils/common";
 import Typography from "@mui/material/Typography";
 import {getLocalNetwork} from "../../../utils/localHelper";
+import { BigNumber } from "bignumber.js";
 
 const guessResult = {
   0:"Draw",
@@ -213,7 +214,7 @@ export default function FingerGuessing() {
 
                         <Alert severity="info">
                             This Banker Amount: {bankAmount} , max input amount{" "}
-                            {bankAmount / 10}{" "}
+                            {new BigNumber(bankAmount).div(10).toString()}{" "}
                         </Alert>
 
                         <TextField

--- a/src/pages/Game/Showdown/index.tsx
+++ b/src/pages/Game/Showdown/index.tsx
@@ -22,7 +22,7 @@ import {getEventsByTxnHash, getTxnData} from "../../../utils/sdk";
 import {sleep} from "../../../utils/common";
 import Typography from "@mui/material/Typography";
 import {getLocalNetwork} from "../../../utils/localHelper";
-
+import { BigNumber } from "bignumber.js";
 
 export default function Showdown() {
     const {t} = useTranslation();
@@ -156,7 +156,7 @@ export default function Showdown() {
                     </Box>
 
                     <Alert severity="info">This Banker Amount: {bankAmount} , max input
-                        amount {bankAmount / 10}  </Alert>
+                        amount {new BigNumber(bankAmount).div(10).toString()}  </Alert>
 
 
                     <TextField


### PR DESCRIPTION
修复 issue #61 

现状：
```
This Banker Amount: 37.3 , max input amount 3.7299999999999995
```
修复后：
```
This Banker Amount: 37.3 , max input amount 3.73
```

**建议:**
在 web3 应用中，涉及的金融数字居多，对于浮点数运算的精度以及大数溢出的问题，建议采用 `bignumber.js`

例如，类似的 issue （issue #46 ：发行 token 时精度问题）

> 在页面：https://starcoinorg.github.io/dapps/#/stc/issue/token
发行：1152921504606846976 个Token
发行成功后实际上钱包里是：1,152,921,504,606,847,000 个


例如：
```
console.log(1152921504606846976); // 结果：1152921504606847000 【精度丢失】
console.log(new BigNumber(1152921504606846976).toString()); // 结果：1152921504606847000 【精度丢失】
console.log(new BigNumber('1152921504606846976').toString()); // 结果：1152921504606846976  【正确】
```
js 中的数超过 2^53 - 1 的会丢失精度，可以使用 `bignumber.js` 将大数以字符串的形式传入，如上述例子的第三行所示。
